### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "19:00"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5


### PR DESCRIPTION
### Summary

Dependabot enables us to keep our software secure and up-to-date by opening version-update and vulnerability-update PRs that the user can choose to merge. 

Here's a blog that explores Depenabot in detail: [Blog](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)

Here's a [reference ](https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/) for configuring Depenabot to work with Flutter/Dart ecosystems.

### Additional Steps

Dependabot needs to be enabled from the `Dependabot` menu under `Settings` tab in the GitHub repository.